### PR TITLE
change deprecated stat() to db.command()

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.17.1",
     "minimist": "^1.2.5",
-    "mongodb": "^3.6.4",
+    "mongodb": "^6.5.0",
     "openai": "^4.24.1"
   },
   "bin": {

--- a/src/controllers/common.js
+++ b/src/controllers/common.js
@@ -54,10 +54,9 @@ function listCollections(req, res, next) {
       collections = collections.filter(collection => !collection.name.startsWith('system.'));
       let proms = [];
       collections.forEach(collection => {
-        proms.push(dataAccessAdapter.ConnectToCollection(
-          dbName,
-          collection.name
-        ).stats()
+        proms.push(dataAccessAdapter.ConnectToDb(
+          dbName
+        ).command({ collStats: collection.name })
           .then((stats) => {
             collection.stats = {
               count: stats.count,

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -6,6 +6,7 @@ class Model {
       dbName,
       collectionName
     );
+    this.modelArgs = [dbName, collectionName];
   }
 
   find(query, filter = {}) {
@@ -52,7 +53,8 @@ class Model {
   }
 
   stats() {
-    return this.collection.stats();
+    const [dbName, colName] = this.modelArgs;
+    return dataAccessAdapter.ConnectToDb(dbName).command({ collStats: colName });
   }
 }
 


### PR DESCRIPTION
fix for [#132](https://github.com/arunbandari/mongo-gui/issues/132)

i have up-to 75 collections in a database.

calling [db.collection.stats()](https://github.com/arunbandari/mongo-gui/blob/b57e51542f93dc0e338722f6f3cdd8bee9ac213d/src/controllers/common.js#L60) simultaneously at Promise.all for this amount of collections causes mongodb to crash and exit

changing to `db.command({ collStats: collection.name })` fixes it

[db.collection.stats()](https://www.mongodb.com/docs/manual/reference/method/db.collection.stats/) has also been deprecated and removed